### PR TITLE
Update eg_01_hello_world/Makefile, Fixed KDIR naming error.

### DIFF
--- a/eg_01_hello_world/Makefile
+++ b/eg_01_hello_world/Makefile
@@ -8,15 +8,15 @@ CFLAGS_hello_world.o := -DDEBUG
 
 else
 # In normal make context
-KDIR ?= /lib/modules/$(shell uname -r)/build
+KERNELDIR ?= /lib/modules/$(shell uname -r)/build
 PWD := $(shell pwd)
 
 .PHONY: modules
 modules:
-	$(MAKE) -C $(KDIR) M=$(PWD) modules
+	$(MAKE) -C $(KERNELDIR) M=$(PWD) modules
 
 .PHONY: clean
 clean:
-	$(MAKE) -C $(KDIR) M=$(PWD) clean
+	$(MAKE) -C $(KERNELDIR) M=$(PWD) clean
 
 endif


### PR DESCRIPTION
Fixed KDIR naming error, KDIR is replaced with KERNELDIR.